### PR TITLE
Add window loaded handler to embedded API using SingletonSwitchboard

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardGrid.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardGrid.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { addAlpha, css, styled, t } from '@superset-ui/core';
 import { EmptyStateBig } from 'src/components/EmptyState';
+import SingletonSwitchboard from '@superset-ui/switchboard';
 import { componentShape } from '../util/propShapes';
 import DashboardComponent from '../containers/DashboardComponent';
 import DragDroppable from './dnd/DragDroppable';
@@ -170,6 +171,19 @@ class DashboardGrid extends React.PureComponent {
 
   handleChangeTab({ pathToTabIndex }) {
     this.props.setDirectPathToChild(pathToTabIndex);
+  }
+
+  componentDidMount() {
+    const size = {
+      width: document.body.scrollWidth,
+      height: document.querySelector('.dashboard-grid')?.offsetHeight || 0,
+    };
+    const msg = {
+      laded: true,
+      documentReadyState: document.readyState,
+      size,
+    };
+    SingletonSwitchboard.emit('windowLoaded', msg);
   }
 
   render() {

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -19,6 +19,8 @@
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { store } from '../views/store';
 import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
+import SingletonSwitchboard from '@superset-ui/switchboard';
+
 
 const bootstrapData = getBootstrapData();
 
@@ -39,6 +41,7 @@ type EmbeddedSupersetApi = {
     chartTitleToScroll?: string;
   }) => void;
   getDashboardState: () => Record<string, unknown>;
+  setWindowLoadedHandler: () => void;
 };
 
 const getScrollSize = (): Size => ({
@@ -125,6 +128,21 @@ const setActiveTabByName = ({
   }
 };
 
+const onWindowLoaded = () => {
+  if (document.readyState === 'complete') {
+    const msg = {
+      laded: true,
+      documentReadyState: document.readyState,
+    };
+    SingletonSwitchboard.emit('windowLoaded', msg);
+    window.removeEventListener('load', onWindowLoaded);
+  } else {
+    window.addEventListener('load', () => onWindowLoaded());
+  }
+};
+
+const setWindowLoadedHandler = () => onWindowLoaded();
+
 const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
 
 const getDashboardState = () => store?.getState()?.dashboardState || [];
@@ -135,4 +153,5 @@ export const embeddedApi: EmbeddedSupersetApi = {
   getActiveTabs,
   getDashboardState,
   setActiveTabByName,
+  setWindowLoadedHandler,
 };

--- a/superset-frontend/src/embedded/api.tsx
+++ b/superset-frontend/src/embedded/api.tsx
@@ -19,8 +19,6 @@
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { store } from '../views/store';
 import { getDashboardPermalink as getDashboardPermalinkUtil } from '../utils/urlUtils';
-import SingletonSwitchboard from '@superset-ui/switchboard';
-
 
 const bootstrapData = getBootstrapData();
 
@@ -41,7 +39,6 @@ type EmbeddedSupersetApi = {
     chartTitleToScroll?: string;
   }) => void;
   getDashboardState: () => Record<string, unknown>;
-  setWindowLoadedHandler: () => void;
 };
 
 const getScrollSize = (): Size => ({
@@ -128,20 +125,6 @@ const setActiveTabByName = ({
   }
 };
 
-const onWindowLoaded = () => {
-  if (document.readyState === 'complete') {
-    const msg = {
-      laded: true,
-      documentReadyState: document.readyState,
-    };
-    SingletonSwitchboard.emit('windowLoaded', msg);
-    window.removeEventListener('load', onWindowLoaded);
-  } else {
-    window.addEventListener('load', () => onWindowLoaded());
-  }
-};
-
-const setWindowLoadedHandler = () => onWindowLoaded();
 
 const getActiveTabs = () => store?.getState()?.dashboardState?.activeTabs || [];
 
@@ -153,5 +136,4 @@ export const embeddedApi: EmbeddedSupersetApi = {
   getActiveTabs,
   getDashboardState,
   setActiveTabByName,
-  setWindowLoadedHandler,
 };

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -213,6 +213,10 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       'setActiveTabByName',
       embeddedApi.setActiveTabByName,
     );
+    Switchboard.defineMethod(
+      'setWindowLoadedHandler',
+      embeddedApi.setWindowLoadedHandler,
+    );
     Switchboard.start();
   }
 });

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -213,10 +213,6 @@ window.addEventListener('message', function embeddedPageInitializer(event) {
       'setActiveTabByName',
       embeddedApi.setActiveTabByName,
     );
-    Switchboard.defineMethod(
-      'setWindowLoadedHandler',
-      embeddedApi.setWindowLoadedHandler,
-    );
     Switchboard.start();
   }
 });


### PR DESCRIPTION
- Integrate SingletonSwitchboard to emit 'windowLoaded' event when the window load completes.
- Define a new method `setWindowLoadedHandler` in embedded API.
- Register `setWindowLoadedHandler` with Switchboard in the embedded page initializer.

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
